### PR TITLE
Skip repeated keys on SDL2

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -787,6 +787,8 @@ static void process_keyboard_event(const SDL_Event &event)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (event.key.windowID != video->window_id)
 		return;
+	if (event.key.repeat > 0)
+		return;
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)


### PR DESCRIPTION
They are always enabled, so we must explicitly skip them, else they flood and confuse the IKBD.

As a test case, open a TOS2win shell, hit the up arrow for a while. When you release the key you won't be able to type anything else. It worked fine with SDL1 though.

I thought I had a bug in qemacs that made it hang after a while but it actually was the up key which kept repeating due to this.