### PR TITLE
Added snap support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ matrix:
   include:
     - os: linux
       language: c
-      dist: trusty
+      dist: xenial
       sudo: required
+      services: docker
     - os: osx
       osx_image: xcode8.3
       language: objective-c
@@ -33,10 +34,12 @@ matrix:
       dist: xenial
       env: 
         - is=deploy
+      services: docker
         
 branches:
   only:
     - master
+    - dev
 
 compiler:
   - gcc
@@ -57,6 +60,8 @@ script:
   - . ./.travis/build.sh
 
 deploy:
+  on:
+    all_branches: true
   skip_cleanup: true
   provider: script
   script: .travis/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ matrix:
 branches:
   only:
     - master
-    - dev
 
 compiler:
   - gcc
@@ -60,8 +59,6 @@ script:
   - . ./.travis/build.sh
 
 deploy:
-  on:
-    all_branches: true
   skip_cleanup: true
   provider: script
   script: .travis/deploy.sh

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -30,6 +30,22 @@ if ! ( echo $is | grep -q deploy ); then
 	NO_CONFIGURE=1 ./autogen.sh
 fi
 export VERSION
+tag_set() {
+	isrelease=false
+	ATAG=${VERSION}${archive_tag}
+	tag=`git tag --points-at ${TRAVIS_COMMIT}`
+	case $tag in
+		ARANYM_*)
+			isrelease=true
+			;;
+		*)
+			ATAG=${VERSION}${archive_tag}-${SHORT_ID}
+			;;
+	esac
+	export ATAG
+	export isrelease
+}
+export -f tag_set
 
 case $CPU_TYPE in
 	i[3456]86 | x86_64 | arm*) build_jit=true ;;
@@ -74,6 +90,7 @@ linux)
 		cd "${BUILDROOT}"
 		tar cvfJ "${OUT}/${ARCHIVE}" .
 		)
+		tag_set
 		(
 		export top_srcdir=`pwd`
 		cd appimage
@@ -154,19 +171,7 @@ osx)
 esac
 
 export ARCHIVE
-isrelease=false
-ATAG=${VERSION}${archive_tag}
-tag=`git tag --points-at ${TRAVIS_COMMIT}`
-case $tag in
-	ARANYM_*)
-		isrelease=true
-		;;
-	*)
-		ATAG=${VERSION}${archive_tag}-${SHORT_ID}
-		;;
-esac
-export ATAG
-export isrelease
+tag_set
 
 if $isrelease; then
 	make dist
@@ -176,4 +181,5 @@ if $isrelease; then
 	done
 fi
 fi
+tag_set
 fi

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -31,20 +31,6 @@ if ! ( echo $is | grep -q deploy ); then
 fi
 export VERSION
 
-isrelease=false
-ATAG=${VERSION}${archive_tag}
-tag=`git tag --points-at ${TRAVIS_COMMIT}`
-case $tag in
-	ARANYM_*)
-		isrelease=true
-		;;
-	*)
-		ATAG=${VERSION}${archive_tag}-${SHORT_ID}
-		;;
-esac
-export ATAG
-export isrelease
-
 case $CPU_TYPE in
 	i[3456]86 | x86_64 | arm*) build_jit=true ;;
 	*) build_jit=false ;;
@@ -168,6 +154,19 @@ osx)
 esac
 
 export ARCHIVE
+isrelease=false
+ATAG=${VERSION}${archive_tag}
+tag=`git tag --points-at ${TRAVIS_COMMIT}`
+case $tag in
+	ARANYM_*)
+		isrelease=true
+		;;
+	*)
+		ATAG=${VERSION}${archive_tag}-${SHORT_ID}
+		;;
+esac
+export ATAG
+export isrelease
 
 if $isrelease; then
 	make dist

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -297,8 +297,10 @@ if ! ( echo $is | grep -q deploy ); then # build job
 			if ! ( echo $ar | grep -q no ); then # Except if is not arm linux
 				echo "------------ normal --------------------"
 				normal_deploy
-				bined
-				snap_create
+				if ! [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+					bined
+					snap_create
+				fi
 			else # if arm finally use cache
 				echo "------------ cache --------------------"
 				cache_deploy
@@ -315,7 +317,9 @@ if ! ( echo $is | grep -q deploy ); then # build job
 else # deploy job
 	echo "------------ deploy --------------------"
 	uncache_deploy
-	bined
-	snap_create
+	if ! [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+		bined
+		snap_create
+	fi
 fi
 fi

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -219,10 +219,10 @@ function uncache_deploy {
 	# and package all builds.
 	export ARCHIVE="${PROJECT_LOWER}-${ATAG}.tar.xz"
 	(
-		sudo chown root "$BUILDROOT${bindir}/aratapif"
-		sudo chgrp root "$BUILDROOT${bindir}/aratapif"
-		sudo chmod 4755 "$BUILDROOT${bindir}/aratapif"
 		cd "${BUILDROOT}"
+		sudo chown root "usr/bin/aratapif"
+		sudo chgrp root "usr/bin/aratapif"
+		sudo chmod 4755 "usr/bin/aratapif"
 		tar cvfJ "${OUT}/${ARCHIVE}" .
 	)
 

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -55,7 +55,7 @@ function snap_create {
 	if $isrelease; then
 		echo "Stable release on Snap"
 		case "$CPU_TYPE" in
-			64)
+			x86_64)
 				revision=$(snapcraft status $SNAP_NAME | grep 'edge' | awk '{print $NF}' | head -n 1)
 			;;
 			arm)

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -49,7 +49,7 @@ function snap_create {
 	echo "CPU_TYPE=$CPU_TYPE" >> env.list
 	sed -i "0,/aranym/ s/aranym/${SNAP_NAME}/" snap/snapcraft.yaml
 	sed -i "0,/version:/ s/.*version.*/version: $VERSION/" snap/snapcraft.yaml
-	docker run --rm --env-file env.list -v "$PWD":/build -w /build snapcore/snapcraft:beta bash \
+	docker run --rm --env-file env.list -v "$PWD":/build -w /build sagu/docker-snapcraft:latest bash \
       -c 'apt update -qq && echo $SNAP_TOKEN | snapcraft login --with -  && snapcraft version && snapcraft --target-arch=$CPU_TYPE && snapcraft push --release=edge *.snap'
 	rm env.list
 	if $isrelease; then
@@ -58,8 +58,11 @@ function snap_create {
 			x86_64)
 				revision=$(snapcraft status $SNAP_NAME | grep 'edge' | awk '{print $NF}' | head -n 1)
 			;;
-			arm)
-				revision=$(snapcraft status $SNAP_NAME | grep 'edge' | awk '{print $NF}' | tail -n 1)
+			i386)
+				revision=$(snapcraft status $SNAP_NAME --arch i386 | grep 'edge' | awk '{print $NF}')
+			;;
+			armhf)
+				revision=$(snapcraft status $SNAP_NAME --arch armhf | grep 'edge' | awk '{print $NF}')
 			;;
 			*)
 				echo "Wrong arch in deploy for snap"

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -48,6 +48,7 @@ function snap_create {
 	echo "SNAP_TOKEN=$SNAP_TOKEN" > env.list
 	echo "CPU_TYPE=$CPU_TYPE" >> env.list
 	sed -i "0,/aranym/ s/aranym/${SNAP_NAME}/" snap/snapcraft.yaml
+	sed -i "0,/version:/ s/.*version.*/version: $VERSION/" snap/snapcraft.yaml
 	docker run --rm --env-file env.list -v "$PWD":/build -w /build snapcore/snapcraft:beta bash \
       -c 'apt update -qq && echo $SNAP_TOKEN | snapcraft login --with -  && snapcraft version && snapcraft --target-arch=$CPU_TYPE && snapcraft push --release=edge *.snap'
 	rm env.list

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -69,6 +69,7 @@ function snap_create {
 		echo "Stable release on Snap"
 		docker run --rm --env-file env.list -v "$PWD":/build -w /build sagu/docker-snapcraft:latest bash \
       -c 'apt update -qq && echo $SNAP_TOKEN | snapcraft login --with -  && snapcraft version && export revision=$(snapcraft status $SNAP_NAME --arch $CPU_TYPE | grep "edge" | awk '\''{print $NF}'\'') && snapcraft release $SNAP_NAME $revision stable'
+	fi
 	rm env.list
 }
 

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -47,6 +47,7 @@ function snap_create {
 	echo $SNAP_TOKEN | snapcraft login --with -
 	echo "SNAP_TOKEN=$SNAP_TOKEN" > env.list
 	echo "CPU_TYPE=$CPU_TYPE" >> env.list
+	sed -i "0,/aranym/ s/aranym/${SNAP_NAME}/" snap/snapcraft.yaml
 	docker run --rm --env-file env.list -v "$PWD":/build -w /build snapcore/snapcraft:beta bash \
       -c 'apt update -qq && echo $SNAP_TOKEN | snapcraft login --with -  && snapcraft version && snapcraft --target-arch=$CPU_TYPE && snapcraft push --release=edge *.snap'
 	rm env.list

--- a/.travis/install_prerequisities.sh
+++ b/.travis/install_prerequisities.sh
@@ -7,6 +7,10 @@ sudo apt-get install -y \
 	xz-utils \
 	libjson-perl \
 	libwww-perl
+if ! ( echo $ar | grep -q arm ); then
+	sudo snap install multipass --beta --classic
+	sudo snap install snapcraft --classic
+fi
 if ! ( echo $is | grep -q deploy ); then
 echo rvm_autoupdate_flag=0 >> ~/.rvmrc
 

--- a/.travis/install_prerequisities.sh
+++ b/.travis/install_prerequisities.sh
@@ -7,10 +7,7 @@ sudo apt-get install -y \
 	xz-utils \
 	libjson-perl \
 	libwww-perl
-if ! ( echo $ar | grep -q arm ); then
-	sudo snap install multipass --beta --classic
-	sudo snap install snapcraft --classic
-fi
+
 if ! ( echo $is | grep -q deploy ); then
 echo rvm_autoupdate_flag=0 >> ~/.rvmrc
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ Implement NF_EXIT feature
 2019/03/09
 Add armhf automated builds
 
-Contributed by sagudev <samo@erazer.Home>
+Contributed by sagudev <samo.golez@gmail.com>
 
 
 2019/01/03

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,142 @@
+name: aranym
+base: core18
+version: 1.0.2
+summary: Atari Running on Any Machine
+description: >
+  ARAnyM is a multiplatform virtual machine (a software layer, or an emulator) for
+  running Atari ST/TT/Falcon operating systems and applications on almost any hardware
+  with many host operating systems. The reason for writing ARAnyM is to provide
+  Atari power users with faster and better machines. The ultimate goal is to create
+  a new platform where TOS/GEM applications could continue to live forever.
+
+grade: stable # must be 'stable' to release into candidate/stable channels is devel or stable
+confinement: strict
+
+environment:
+  LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio
+
+parts:
+  aranym:
+    plugin: dump
+    source: bined.tar.xz
+    stage-packages:
+      - libosmesa6-dev
+      - libgl1-mesa-dev
+      - libglu1-mesa-dev
+      - libsdl1.2-dev
+      - libsdl-image1.2-dev
+      - libusb-dev
+      - libusb-1.0-0-dev
+      - libslang2
+      - pulseaudio
+      - util-linux
+
+layout:
+  /usr/share/aranym/wm_icon.bmp:
+    bind-file: $SNAP/usr/share/aranym/wm_icon.bmp
+
+apps:
+  aranym:
+    command: aranym
+    plugs:
+    - desktop
+    - desktop-legacy
+    - wayland
+    - unity7
+    - alsa
+    - home
+    - network
+    - opengl
+    - pulseaudio
+    - screen-inhibit-control
+    - hardware-observe
+    - mount-observe
+    - network-bind
+    - network-control
+    - network-manager
+    - network-observe
+    - network-setup-control
+    - network-setup-observe
+    - network-status
+    - optical-drive
+    - raw-usb
+    - removable-media
+    - system-observe
+  aranym-jit:
+    command: aranym-jit
+    plugs:
+    - desktop
+    - desktop-legacy
+    - wayland
+    - unity7
+    - alsa
+    - home
+    - network
+    - opengl
+    - pulseaudio
+    - screen-inhibit-control
+    - hardware-observe
+    - mount-observe
+    - network-bind
+    - network-control
+    - network-manager
+    - network-observe
+    - network-setup-control
+    - network-setup-observe
+    - network-status
+    - optical-drive
+    - raw-usb
+    - removable-media
+    - system-observe
+  aranym-mmu:
+    command: aranym-mmu
+    plugs:
+    - desktop
+    - desktop-legacy
+    - wayland
+    - unity7
+    - alsa
+    - home
+    - network
+    - opengl
+    - pulseaudio
+    - screen-inhibit-control
+    - hardware-observe
+    - mount-observe
+    - network-bind
+    - network-control
+    - network-manager
+    - network-observe
+    - network-setup-control
+    - network-setup-observe
+    - network-status
+    - optical-drive
+    - raw-usb
+    - removable-media
+    - system-observe
+  aratapif:
+    command: aratapif
+    plugs:
+    - desktop
+    - desktop-legacy
+    - wayland
+    - unity7
+    - alsa
+    - home
+    - network
+    - opengl
+    - pulseaudio
+    - screen-inhibit-control
+    - hardware-observe
+    - mount-observe
+    - network-bind
+    - network-control
+    - network-manager
+    - network-observe
+    - network-setup-control
+    - network-setup-observe
+    - network-status
+    - optical-drive
+    - raw-usb
+    - removable-media
+    - system-observe


### PR DESCRIPTION
See #12 
For successful build see: https://travis-ci.org/sagudev/aranym/builds/507500817
For snaps go to: https://snapcraft.io/sagudev-aranym/releases

TODO before merging:
- [ ] Create snap on https://snapcraft.io/ called aranym
- [ ] Create Snapcraft token with `snapcraft export-login --snaps aranym -`
- [ ] Add `SNAP_TOKEN=your_snapcraft_token_here` to Travis like Bintray api key.
- [ ] Rerun Travis build

**Aranym 64bit is now build in Xenial**