### PR TITLE
Fixe compiler warnings from GCC 9.1

### DIFF
--- a/src/Unix/host_filesys_unix.cpp
+++ b/src/Unix/host_filesys_unix.cpp
@@ -37,8 +37,8 @@ char *HostFilesys::getHomeFolder(char *buffer, unsigned int bufsize)
 
 	// Unix-like systems define HOME variable as the user home folder
 	char *home = getenv("HOME");
-	if ( home )
-		strncpy( buffer, home, bufsize );
+	if (home && strlen(home) < bufsize)
+		strcpy(buffer, home);
 	return buffer;
 }
 

--- a/src/Unix/linux/ethernet_linux.cpp
+++ b/src/Unix/linux/ethernet_linux.cpp
@@ -228,7 +228,7 @@ int TunTapEthernetHandler::tapOpen(char *dev)
 
     ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
     if( *dev )
-	strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+	memcpy(ifr.ifr_name, dev, MIN(strlen(dev), IFNAMSIZ));
 
     if (ioctl(fd, TUNSETIFF, (void *) &ifr) < 0) {
 	    if (errno != EBADFD)

--- a/src/natfeat/hostfs.cpp
+++ b/src/natfeat/hostfs.cpp
@@ -991,7 +991,7 @@ void HostFs::transformFileName( char* dest, const char* source )
 			// and the extension
 			extLen = MIN(3,extLen);
 			dest[nameLen] = '.';
-			strncpy(&dest[nameLen+1], dot, extLen);
+			memcpy(&dest[nameLen+1], dot, extLen);
 		}
 
 		dest[ nameLen+extLen+1 ] = '\0';


### PR DESCRIPTION
GCC 9.1 emits a couple of warnings related to strncpy() when compiling Aranym. These patches silence those compiler warnings.