### PR TITLE
Fix builds with --disable-gui

### DIFF
--- a/src/hostscreen.cpp
+++ b/src/hostscreen.cpp
@@ -38,6 +38,7 @@
 #include "parameters.h"	/* bx_options */
 #include "main.h"	/* QuitEmulator */
 #include "input.h"
+#include "host_filesys.h"
 
 #ifdef NFVDI_SUPPORT
 # include "nf_objs.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -340,7 +340,9 @@ bool InitOS(void)
 
 bool InitAll(void)
 {
+#ifdef SDL_GUI
 	bool needToReboot = false;
+#endif
 
 #ifndef NOT_MALLOC
 	if (ROMBaseHost == NULL) {
@@ -434,13 +436,13 @@ bool InitAll(void)
 		}
 	}
 
+#ifdef SDL_GUI
 	if (! InitOS())
 	{
 		startupGUI = true;
 		needToReboot = true;
 	}
 	
-#ifdef SDL_GUI
 	isGuiAvailable = SDLGui_Init();
 	
 	if (isGuiAvailable && startupGUI) {


### PR DESCRIPTION
I wonder whether this is even supported now because when I try the resulting build, a window briefly pops up before the whole program exits. If it's not supported, the option should probably be dropped?