### PR TITLE
JIT back in snap

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -58,12 +58,12 @@ function snap_create {
 		;;
 		aarch)
 			snap_cpu=arm64
-			sed -i '65,90d' snap/snapcraft.yaml # no jit in aarch64
+			sed -i '65,91d' snap/snapcraft.yaml # no jit in aarch64
 		;;
 		*)
 			echo "Wrong arch in deploy for snap"
 		;;
-		esac
+	esac
 	echo "SNAP_TOKEN=$SNAP_TOKEN" > env.list
 	echo "snap_cpu=$snap_cpu" >> env.list
 	echo "SNAP_NAME=$SNAP_NAME" >> env.list

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -58,6 +58,7 @@ function snap_create {
 		;;
 		aarch)
 			snap_cpu=arm64
+			sed -i '65,90d' snap/snapcraft.yaml # no jit in aarch64
 		;;
 		*)
 			echo "Wrong arch in deploy for snap"
@@ -66,7 +67,6 @@ function snap_create {
 	echo "SNAP_TOKEN=$SNAP_TOKEN" > env.list
 	echo "snap_cpu=$snap_cpu" >> env.list
 	echo "SNAP_NAME=$SNAP_NAME" >> env.list
-	sed -i '65,90d' snap/snapcraft.yaml # no jit in aarch64
 	sed -i "0,/aranym/ s/aranym/${SNAP_NAME}/" snap/snapcraft.yaml
 	sed -i "0,/version:/ s/.*version.*/version: $VERSION/" snap/snapcraft.yaml
 	docker run --rm --env-file env.list -v "$PWD":/build -w /build sagu/docker-snapcraft:latest bash \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,7 @@ apps:
     - system-observe
   aranym-jit:
     command: aranym-jit
+    aliases: [aranym-jit]
     plugs:
     - desktop
     - desktop-legacy
@@ -90,6 +91,7 @@ apps:
     - system-observe
   aranym-mmu:
     command: aranym-mmu
+    aliases: [aranym-mmu]
     plugs:
     - desktop
     - desktop-legacy
@@ -116,6 +118,7 @@ apps:
     - system-observe
   aratapif:
     command: aratapif
+    aliases: [aratapif]
     plugs:
     - desktop
     - desktop-legacy


### PR DESCRIPTION
Fix for #59 and aliases so now you can use these commands from snap:
```bash
> aranym

> aranym-mmu

> aranym-jit

> aratapif
```