### PR TITLE
Compile C code with -Wmissing-prototypes and -Wstrict-prototypes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1679,6 +1679,12 @@ dnl UAE CPU sources for all architectures.
 CPUSRCS="$CPUSRCS $JITSRCS"
 GENCPUSRCS="$GENCPUSRCS cpudefs.cpp cpustbl.cpp cpufunctbl.cpp $GENJITSRCS"
 
+if [[ "x$GCC" = "xyes" ]]; then
+  WFLAGS="-Wextra -Wall -Wundef"
+else
+  WFLAGS=""
+fi
+
 dnl Remove the "-g" option if set for GCC.
 if [[ "x$GCC" = "xyes" ]]; then
   if test "$ac_test_CFLAGS" != set; then
@@ -1690,13 +1696,8 @@ if [[ "x$GCC" = "xyes" ]]; then
 fi
 if [[ "x$WANT_NATDEBUG" = "xyes" ]]; then
   DBGSP="-g"
-  WFLAGS=""
-  if [[ "x$GCC" = "xyes" ]]; then
-    WFLAGS="$WFLAGS -W -Wall -Wundef"
-  fi
 else
   DBGSP=""
-  WFLAGS=""
 fi
 
 if [[ "x$WANT_FULLDEBUG" = "xyes" ]]; then

--- a/configure.ac
+++ b/configure.ac
@@ -1681,6 +1681,8 @@ GENCPUSRCS="$GENCPUSRCS cpudefs.cpp cpustbl.cpp cpufunctbl.cpp $GENJITSRCS"
 
 if [[ "x$GCC" = "xyes" ]]; then
   WFLAGS="-Wextra -Wall -Wundef"
+  # The following are for plain C only:
+  CFLAGS="$CFLAGS -Wmissing-prototypes -Wstrict-prototypes"
 else
   WFLAGS=""
 fi

--- a/src/Unix/aratapif.c
+++ b/src/Unix/aratapif.c
@@ -96,7 +96,7 @@ static int set_ip_using(const char *name, unsigned long c, const char *ip, const
     return 0;
 }
 
-int set_mtu(const char *name, int mtu_size)
+static int set_mtu(const char *name, int mtu_size)
 {
     struct ifreq ifr;
 

--- a/src/adler32.c
+++ b/src/adler32.c
@@ -20,6 +20,7 @@
 */
 
 #include "SDL_compat.h"
+#include "adler32.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/dsp_core.c
+++ b/src/dsp_core.c
@@ -827,7 +827,7 @@ static void dsp_core_hostport_update_trdy(dsp_core_t *dsp_core)
 }
 
 /* Host port transfer ? (dsp->host) */
-void dsp_core_dsp2host(dsp_core_t *dsp_core)
+static void dsp_core_dsp2host(dsp_core_t *dsp_core)
 {
 	/* RXDF = 1 ==> host hasn't read the last value yet */
 	if (dsp_core->hostport[CPU_HOST_ISR] & (1<<CPU_HOST_ISR_RXDF)) {
@@ -854,7 +854,7 @@ void dsp_core_dsp2host(dsp_core_t *dsp_core)
 }
 
 /* Host port transfer ? (host->dsp) */
-void dsp_core_host2dsp(dsp_core_t *dsp_core)
+static void dsp_core_host2dsp(dsp_core_t *dsp_core)
 {
 	/* TXDE = 1 ==> nothing to transfer from host port */
 	if (dsp_core->hostport[CPU_HOST_ISR] & (1<<CPU_HOST_ISR_TXDE)) {


### PR DESCRIPTION
These compiler options help to avoid bugs (e.g. when an implementation does not match its prototype in the header) and help to find spots of optimizations (when functions can be declared as static). It's always good to enable them for C code.