### PR TITLE
Fix #72: key mapping issue for macOS systems using SDL2

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -84,7 +84,11 @@ SDL_Joystick *sdl_joysticks[4]={
 #define UNDEFINED_OFFSET	((unsigned int)-1)
 
 #ifdef OS_darwin
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+#define KEYBOARD_TRANSLATION	KEYSYM_SCANCODE
+#else
 #define KEYBOARD_TRANSLATION	KEYSYM_MACSCANCODE
+#endif
 #else
 #define KEYBOARD_TRANSLATION	KEYSYM_SCANCODE
 #endif


### PR DESCRIPTION
I could reproduce issue #72 on macOS BigSur and have found that the old input method is not needed anymore with SDL2, as there are always scancodes for each key press delivered. 
If I remember correctly the alternate input mapping has been created because SDL didn't have a valid scan code for all key presses. Therefore some kind of reverse mapping had been used. This mapping is no more necessary for SDL2.