### PR TITLE
Support for switching the snapshot BMP internal format

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -25,6 +25,9 @@ BootDrive =
 # UTC (GMT) or localtime? Set GMT for Linux-m68k or FreeMiNT with timezones
 GMTime = No
 
+# Snapshots use older BMP format (more compatible) or newer BMP format
+SnapshotOlderFormat = Yes
+
 
 # Hotkeys: invoke certain ARAnyM functions by pressing a key combination
 # Format: function = key code : modifiers combination

--- a/src/hostscreen.cpp
+++ b/src/hostscreen.cpp
@@ -323,6 +323,8 @@ void HostScreen::writeSnapshot(SDL_Surface *surf)
 	sprintf(filename, "snap%03d.bmp", snapCounter++ );
 	safe_strncpy(path, bx_options.snapshot_dir, sizeof(path));
 	addFilename(path, filename, sizeof(path));
+	SDL_SetHint(SDL_HINT_BMP_SAVE_LEGACY_FORMAT,
+				bx_options.snapshot_oldformat ? "true" : "false");
 	if (SDL_SaveBMP(surf, path) < 0)
 	{
 #ifdef __CYGWIN__

--- a/src/include/parameters.h
+++ b/src/include/parameters.h
@@ -323,6 +323,7 @@ typedef struct {
   bx_hotkeys_t		hotkeys;
   bool			newHardDriveSupport;
   char			snapshot_dir[512];
+  bool			snapshot_oldformat;
 } bx_options_t;
 
 extern bx_options_t bx_options;

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -654,6 +654,7 @@ struct Config_Tag global_conf[]={
 	{ "EpsEnabled", Bool_Tag, &bx_options.cpu.eps_enabled, 0, 0},
 	{ "EpsMax", Int_Tag, &bx_options.cpu.eps_max, 0, 0},
 	{ "SnapshotDir", Path_Tag, bx_options.snapshot_dir, sizeof(bx_options.snapshot_dir), 0},
+	{ "SnapshotOlderFormat", Bool_Tag, &bx_options.snapshot_oldformat, 0, 0},
 	{ NULL , Error_Tag, NULL, 0, 0 }
 };
 
@@ -675,6 +676,7 @@ static void preset_global()
 	bx_options.cpu.eps_enabled = false;
 	bx_options.cpu.eps_max = 20;
 	strcpy(bx_options.snapshot_dir, "snapshots");
+	bx_options.snapshot_oldformat = true;
 }
 
 static void postload_global()


### PR DESCRIPTION
This fixes #85 by changing the default format to "compatible" via an SDL hint.

A global config option is added called `snapshotOlderFormat` which lets you switch between the older and newer format.

This option is not exposed in the setup GUI, as I'm not exactly sure where to start with that.