### PR TITLE
Use libcwrap.h specifically with glibc, not Linux

### DIFF
--- a/src/include/linux/libcwrap.h
+++ b/src/include/linux/libcwrap.h
@@ -1,5 +1,5 @@
 /* glibc bindings for target ABI version glibc 2.11 */
-#if defined(__linux__) && !defined (__LIBC_CUSTOM_BINDINGS_H__) && !defined(__ANDROID__)
+#if defined(__GLIBC__) && defined(__linux__) && !defined (__LIBC_CUSTOM_BINDINGS_H__) && !defined(__ANDROID__)
 
 #if defined (__cplusplus)
 extern "C" {


### PR DESCRIPTION
Other C libraries can be used on Linux (e.g. musl) and glibc supports operating systems other than Linux (e.g. FreeBSD).