### PR TITLE
Fix build with glibc 2.36

### DIFF
--- a/src/Unix/sysdeps.h
+++ b/src/Unix/sysdeps.h
@@ -139,15 +139,12 @@ int fcntl(int __fd, int __cmd, ...) __asm__("fcntl");
 # endif
 #endif
 
-#ifdef TIME_WITH_SYS_TIME
+#ifdef HAVE_SYS_TIME_H
 # include <sys/time.h>
+#endif
+
+#ifdef HAVE_TIME_H
 # include <time.h>
-#else
-# ifdef HAVE_SYS_TIME_H
-#  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
 #endif
 
 #if HAVE_DIRENT_H


### PR DESCRIPTION
Include both `<sys/time.h>` and `<time.h>` if available.

Nothing in aranym defines `TIME_WITH_SYS_TIME`, so on Linux `sysdeps.h` was only including `<sys/time.h>`. This breaks the build with glibc 2.36 since that header doesn't include the definitions of `localtime`, etc.