### PR TITLE
Don't set ARMV6_ASSEMBLY on ARMv7 and later

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1365,9 +1365,7 @@ elif test "$GCC" = yes && $HAVE_ARM; then
 	   ;;
 	armv7*|armv8*|armv9*)
            ASM_OPTIMIZATIONS="ARM/V7+ architecture w optimized flags"
-	   DEFINES="$DEFINES -DARMV6_ASSEMBLY -DARM_ASSEMBLY -DOPTIMIZED_FLAGS"
-           CFLAGS="$CFLAGS -marm"
-           CXXFLAGS="$CXXFLAGS -marm"
+	   DEFINES="$DEFINES -DARM_ASSEMBLY -DOPTIMIZED_FLAGS"
 	   ;;
 	*)
 	   dnl Hack until we find a better way


### PR DESCRIPTION
This was causing a performance regression in Kronos CPU performance test on RPi 4. The precise factor(s) triggering this performance regression haven't been investigated yet but the purpose of this commit is to stop pulling in ARMv6-specific asm code, at least until the regression can be investigated further.