### PR TITLE
Fix crash when enabling OpenGL on macOS

### DIFF
--- a/src/hostscreen_opengl.cpp
+++ b/src/hostscreen_opengl.cpp
@@ -166,6 +166,8 @@ void HostScreenOpenGL::setVideoMode(int width, int height, int bpp)
 			if (window)
 			{
 				SDL_GetWindowDisplayMode(window, &mode);
+				auto context = SDL_GL_CreateContext(window);
+				SDL_GL_MakeCurrent(window, context);
 			}
 		}
 		if (window==NULL) {


### PR DESCRIPTION
On current macOS systems SDL2 is required. To make "OpenGL" rendering available, the `host_screen_opengl.cpp` had to be modified to properly select the correct SDL render driver. There are multiple available and the default is "metal".

The fixed implementation loops over all render drivers and selects the first starting with "opengl" in his name.
This implementation has been successfully tested with SDL 2.24.2 and 2.26.2.

But on an Mac with Apple Silicon there is no measurable difference between the default Metal based renderer and the OpenGL renderer.