### PR TITLE
configure.ac: fix -Wimplicit-function-declaration in TUN/TAP test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1714,7 +1714,7 @@ SDL_CFLAGS=
 SDL_LIBS=
 no_sdl=yes
 no_sdl2=yes
-if test "$OS_TYPE" == darwin -a "$WITH_FINK" = no; then
+if test "$OS_TYPE" = darwin -a "$WITH_FINK" = no; then
 	ARANYM_CHECK_FRAMEWORK(SDL, [])
 	if test "$have_framework_SDL" = yes ; then
 		ARANYM_CHECK_FRAMEWORK_LOCATION(SDL)
@@ -1781,7 +1781,7 @@ SDL_LIBS="$SDL_LIBS -lpthread"
 AM_CONDITIONAL([ENABLE_SDL2], test "$enable_sdl2" = yes)
 #
 # SDL2 on macOS needs 10.6 or above
-if test "$enable_sdl2" = yes -a "$OS_TYPE" == darwin; then
+if test "$enable_sdl2" = yes -a "$OS_TYPE" = darwin; then
 	export MACOSX_DEPLOYMENT_TARGET=10.6
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -558,6 +558,7 @@ AC_CACHE_CHECK([whether TUN/TAP is supported],
     #include <net/if.h>
     #include <net/if_tun.h>
     #endif
+    #include <string.h>
   ]], [[
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration an error by default.

Unfortunately, this can lead to misconfiguration or miscompilation of software as configure tests may then return the wrong result.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2], or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213
[2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.