### PR TITLE
More portable use of sed(1) at configure-time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1682,10 +1682,10 @@ fi
 dnl Remove the "-g" option if set for GCC.
 if [[ "x$GCC" = "xyes" ]]; then
   if test "$ac_test_CFLAGS" != set; then
-    CFLAGS=`echo $CFLAGS | sed -e 's/-g\b//g'`
+    CFLAGS=`echo $CFLAGS | sed 's/-g$//g' | sed 's/-g //g'`
   fi
   if test "$ac_test_CXXFLAGS" != set; then
-    CXXFLAGS=`echo $CXXFLAGS | sed -e 's/-g\b//g'`
+    CXXFLAGS=`echo $CXXFLAGS | sed 's/-g$//g' | sed 's/-g //g'`
   fi
 fi
 if [[ "x$WANT_NATDEBUG" = "xyes" ]]; then


### PR DESCRIPTION
Some of the sed operations that happen in the configure script rely on GNU extensions, which are not enabled by default on some platforms.

E.g. on NetBSD we see junk like this, because `\b` is a GNU-only parameter:

```
checking for isnan... yes
checking for isinf... yes
checking for finite... yes
checking for isnormal... no
checking for signbit... no
sed: 1: "s/-g\b//g
": RE error: trailing backslash (\)
sed: 1: "s/-g\b//g
": RE error: trailing backslash (\)
checking for sdl-config... /usr/pkg/bin/sdl-config
checking for SDL - version >= 1.2.12... yes
checking for jpeglib.h... no
```

My change allows me to run a command like `SED=/usr/pkg/bin/gsed ./configure [...]`, which alleviates the issue.

Or maybe it'd be better to find something that has the same effect as GNU sed's `\b` but is more portable.